### PR TITLE
ci: open PRs for version matrix sync

### DIFF
--- a/.github/workflows/sync-version-matrix.yml
+++ b/.github/workflows/sync-version-matrix.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:
@@ -58,4 +59,14 @@ jobs:
           done
 
       - name: Sync version matrices
-        run: ./scripts/update-version-matrix.sh --apply --commit --push --projects "$PWD/repos"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          ./scripts/update-version-matrix.sh \
+            --apply \
+            --commit \
+            --push \
+            --pr \
+            --branch "chore/version-matrix" \
+            --base "main" \
+            --projects "$PWD/repos"


### PR DESCRIPTION
Update sync workflow to open PRs instead of pushing to protected branches.