### PR TITLE
docs: auto-generate combined changelog

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,19 @@ jobs:
         with:
           go-version: "1.24.x"
 
+      - name: Clone tool repos (for changelog aggregation)
+        run: |
+          set -euo pipefail
+          mkdir -p repos
+          for repo in toolmodel toolindex tooldocs toolrun toolcode toolruntime toolsearch metatools-mcp; do
+            if [ ! -d "repos/$repo/.git" ]; then
+              git clone "https://github.com/jonwraymond/$repo.git" "repos/$repo"
+            fi
+          done
+
+      - name: Generate combined changelog
+        run: ./scripts/generate-combined-changelog.sh --projects "$PWD/repos"
+
       - name: Install D2
         run: |
           go install oss.terrastruct.com/d2@v0.7.1


### PR DESCRIPTION
Run combined changelog generation during docs builds so the aggregated page stays current.