### PR TITLE
chore: use GOPRIVATE and bump toolmodel/tooldocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   test:
     name: Test (Go ${{ matrix.go-version }})
     runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/jonwraymond/*
+      GONOSUMDB: github.com/jonwraymond/*
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint-security.yml
+++ b/.github/workflows/lint-security.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   lint-security:
     runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/jonwraymond/*
+      GONOSUMDB: github.com/jonwraymond/*
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sync-version-matrix.yml
+++ b/.github/workflows/sync-version-matrix.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/jonwraymond/*
+      GONOSUMDB: github.com/jonwraymond/*
     steps:
       - name: Checkout ai-tools-stack
         uses: actions/checkout@v4

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,8 +1,8 @@
 ## Version compatibility (current tags)
 
-- `toolmodel`: `v0.1.3`
+- `toolmodel`: `v0.2.0`
 - `toolindex`: `v0.3.0`
-- `tooldocs`: `v0.1.11`
+- `tooldocs`: `v0.2.0`
 - `toolrun`: `v0.3.0`
 - `toolcode`: `v0.3.0`
 - `toolruntime`: `v0.2.1`

--- a/docs/operations/ci-and-versioning.md
+++ b/docs/operations/ci-and-versioning.md
@@ -8,6 +8,16 @@ Each repo runs CI for:
 - go test
 - lint + security (golangci-lint + gosec)
 
+## Go module privacy (fast tag uptake)
+
+CI sets:
+
+- `GOPRIVATE=github.com/jonwraymond/*`
+- `GONOSUMDB=github.com/jonwraymond/*`
+
+This bypasses the public proxy/sumdb for the org’s modules so newly‑pushed tags
+are immediately usable in CI and local workflows.
+
 ## Version alignment
 
 - `ai-tools-stack/go.mod` is the source of truth.

--- a/docs/operations/stack-changelog.md
+++ b/docs/operations/stack-changelog.md
@@ -5,14 +5,14 @@ Aggregated highlights from each repo’s latest release. For full history, use e
 ## Version matrix
 ### Version compatibility (current tags)
 
-- `toolmodel`: `v0.1.3`
+- `toolmodel`: `v0.2.0`
 - `toolindex`: `v0.3.0`
-- `tooldocs`: `v0.1.11`
+- `tooldocs`: `v0.2.0`
 - `toolrun`: `v0.3.0`
 - `toolcode`: `v0.3.0`
 - `toolruntime`: `v0.2.1`
 - `toolsearch`: `v0.3.0`
-- `metatools-mcp`: `v0.3.0`
+- `metatools-mcp`: `v0.4.0`
 
 Generated from `ai-tools-stack/go.mod`.
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.24.4
 require (
 	github.com/jonwraymond/metatools-mcp v0.4.0
 	github.com/jonwraymond/toolcode v0.3.0
-	github.com/jonwraymond/tooldocs v0.1.11
+	github.com/jonwraymond/tooldocs v0.2.0
 	github.com/jonwraymond/toolindex v0.3.0
-	github.com/jonwraymond/toolmodel v0.1.3
+	github.com/jonwraymond/toolmodel v0.2.0
 	github.com/jonwraymond/toolrun v0.3.0
 	github.com/jonwraymond/toolruntime v0.2.1
 	github.com/jonwraymond/toolsearch v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -58,12 +58,12 @@ github.com/jonwraymond/metatools-mcp v0.4.0 h1:/lK2MKU/SZPXYCRNDL5EccvpZEoAP2FRv
 github.com/jonwraymond/metatools-mcp v0.4.0/go.mod h1:4if0JRqgkOO2T4AUwd6RoDLvGrEHwKFe0rGKWT8tDGY=
 github.com/jonwraymond/toolcode v0.3.0 h1:8Xn62NRH6WfQGinNbq28zZFrCJkayyje2tKJefTmvyI=
 github.com/jonwraymond/toolcode v0.3.0/go.mod h1:UTXveBORgBARjjW0Ay6epDjYlWOJ+HykbvoOOucgbhw=
-github.com/jonwraymond/tooldocs v0.1.11 h1:GU9m269/UWs9kTVMRS5Q3swEnehfsC51LORJn6WWGt0=
-github.com/jonwraymond/tooldocs v0.1.11/go.mod h1:7L9Ur1bN6UlChbdGvQBtuEJ5VnihOwAIhZM01I0bflo=
+github.com/jonwraymond/tooldocs v0.2.0 h1:kiLFp3WaJLxqIGVJwQLHTnbM+1+1JsrE8Si9208QX3Y=
+github.com/jonwraymond/tooldocs v0.2.0/go.mod h1:7L9Ur1bN6UlChbdGvQBtuEJ5VnihOwAIhZM01I0bflo=
 github.com/jonwraymond/toolindex v0.3.0 h1:N5CpXmVqh3bMwnUI2h2eleKS/rOyugOGyGx20Yn2vkI=
 github.com/jonwraymond/toolindex v0.3.0/go.mod h1:IVmqAsu1Dm6HAXOtnnNy+IQIU+zRYHN2lwOFFgeIdSM=
-github.com/jonwraymond/toolmodel v0.1.3 h1:gkgBfOaLlz9WWwrJE5eqeLL/Z6NWbF1nSM+nq3vf0cs=
-github.com/jonwraymond/toolmodel v0.1.3/go.mod h1:2S1YAIv2IGcwxqEaB0V4egvnY7opCdoTNknKJMg2pkE=
+github.com/jonwraymond/toolmodel v0.2.0 h1:1Jne9cyTGeb3VTFxzVx+Rp8x5l3WkZT98a8lQnCML7g=
+github.com/jonwraymond/toolmodel v0.2.0/go.mod h1:2S1YAIv2IGcwxqEaB0V4egvnY7opCdoTNknKJMg2pkE=
 github.com/jonwraymond/toolrun v0.3.0 h1:BNpkfHBjM12opv77iGyxtg6ENEI44stzTBr5dDm5xAc=
 github.com/jonwraymond/toolrun v0.3.0/go.mod h1:osEaTNLfjbCC9rupyzlOwz3nZONL1Nk+YL1fiE3y+ks=
 github.com/jonwraymond/toolruntime v0.2.1 h1:cIGyjRIsD72tX68/bFMCA/tvOBQbXS/JfzTJM+2ba0c=


### PR DESCRIPTION
- Add GOPRIVATE/GONOSUMDB to CI + sync workflows\n- Bump toolmodel + tooldocs to v0.2.0\n- Refresh VERSIONS + stack changelog + docs note