### PR TITLE
docs: update wasm runtime notes and versions

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,12 +7,12 @@
 - `tooldocs`: `v0.2.0`
 - `toolrun`: `v0.3.0`
 - `toolcode`: `v0.3.0`
-- `toolruntime`: `v0.3.1`
+- `toolruntime`: `v0.4.0`
 - `toolsearch`: `v0.3.0`
 - `toolobserve`: `v0.2.0`
 - `toolcache`: `v0.2.0`
 - `toolsemantic`: `v0.2.0`
 - `toolskill`: `v0.2.0`
-- `metatools-mcp`: `v0.4.0`
+- `metatools-mcp`: `v0.5.0`
 
 Generated from `ai-tools-stack/go.mod`.

--- a/docs/components/metatools-mcp.md
+++ b/docs/components/metatools-mcp.md
@@ -33,6 +33,8 @@ profile at startup:
 - `dev` profile (default): unsafe subprocess backend.
 - `standard` profile: Docker sandbox (set `METATOOLS_RUNTIME_PROFILE=standard`).
 - `METATOOLS_DOCKER_IMAGE` overrides the sandbox image name.
+- `METATOOLS_WASM_ENABLED=true` enables the WASM backend (wazero).
+- `METATOOLS_RUNTIME_BACKEND=wasm` selects WASM for the standard profile.
 
 ## Example
 

--- a/docs/components/toolruntime.md
+++ b/docs/components/toolruntime.md
@@ -15,6 +15,13 @@ backends with a single interface.
 - Backends (unsafe host, docker, kubernetes, gvisor, firecracker, wasm)
 - Security profiles and execution limits
 
+## WASM backend
+
+`toolruntime` defines the WASM contracts in `backend/wasm` (Runner, ModuleLoader,
+HealthChecker, StreamRunner). The `metatools-mcp` server provides a wazero-based
+implementation and wires it into `execute_code` when the `toolruntime` build tag
+is enabled.
+
 ## Example
 
 ```go

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/jonwraymond/ai-tools-stack
 go 1.24.4
 
 require (
-	github.com/jonwraymond/metatools-mcp v0.4.0
+	github.com/jonwraymond/metatools-mcp v0.5.0
 	github.com/jonwraymond/toolcode v0.3.0
 	github.com/jonwraymond/tooldocs v0.2.0
 	github.com/jonwraymond/toolindex v0.3.0
 	github.com/jonwraymond/toolmodel v0.2.0
 	github.com/jonwraymond/toolrun v0.3.0
-	github.com/jonwraymond/toolruntime v0.3.1
+	github.com/jonwraymond/toolruntime v0.4.0
 	github.com/jonwraymond/toolsearch v0.3.0
 	github.com/modelcontextprotocol/go-sdk v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 h1:NmZ1PKzSTQbuGHw9DGPFomqkkLW
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3/go.mod h1:zQrxl1YP88HQlA6i9c63DSVPFklWpGX4OWAc9bFuaH4=
 github.com/jonwraymond/metatools-mcp v0.4.0 h1:/lK2MKU/SZPXYCRNDL5EccvpZEoAP2FRvLdeB0aB6d4=
 github.com/jonwraymond/metatools-mcp v0.4.0/go.mod h1:4if0JRqgkOO2T4AUwd6RoDLvGrEHwKFe0rGKWT8tDGY=
+github.com/jonwraymond/metatools-mcp v0.5.0 h1:kvMZMK0PxlNMhzNyKQ3EKirIP9SohJTfhoq8cwg82oI=
+github.com/jonwraymond/metatools-mcp v0.5.0/go.mod h1:3qwpfafJoo8HdzlPjHTm6skompuaKyZypyVEbYXZFcc=
 github.com/jonwraymond/tooladapter v0.1.0 h1:2ARw7QEGgwucwQ9kdY1kJf2cisCOyy/+pnPi7JiZOcE=
 github.com/jonwraymond/tooladapter v0.1.0/go.mod h1:VUMlf7L/Un/STmIoAIizQ8D9c0SjKZMAAU8kZeLFSPU=
 github.com/jonwraymond/tooladapter v0.2.0 h1:gxgN8ni246M0CWO1d9GCZziNqol6qFRuoZixnzR+25A=
@@ -92,6 +94,8 @@ github.com/jonwraymond/toolruntime v0.2.1 h1:cIGyjRIsD72tX68/bFMCA/tvOBQbXS/JfzT
 github.com/jonwraymond/toolruntime v0.2.1/go.mod h1:z4XwbjR3GDj86xIGnhWSR2KkopHgfeN37ZQMIFG4CXI=
 github.com/jonwraymond/toolruntime v0.3.1 h1:GglcQjAFn6Z2WcMcdBrx835i/5ZM7YZ9OEbBcV53CdA=
 github.com/jonwraymond/toolruntime v0.3.1/go.mod h1:TEOW8dU9lH+4q+nFZiVr0JgWTQInwugBULnMaapriOA=
+github.com/jonwraymond/toolruntime v0.4.0 h1:04zjqyVqZosSGgbyVxXITY4HioRrNWE44LJsSOQVkZY=
+github.com/jonwraymond/toolruntime v0.4.0/go.mod h1:TEOW8dU9lH+4q+nFZiVr0JgWTQInwugBULnMaapriOA=
 github.com/jonwraymond/toolsearch v0.3.0 h1:zF3XrLn1pJvU4vV2ZIie59jNSgfTIu7nfPKEQOYxxn8=
 github.com/jonwraymond/toolsearch v0.3.0/go.mod h1:o8nOuJayCzByEjoeicplaLZVhCmExJDNqRvAeRQT9uk=
 github.com/jonwraymond/toolsemantic v0.2.0 h1:zPzmoPZrjhDEVVfUjnxlALhRLk0Htkk9Fr0lXMLHzOM=


### PR DESCRIPTION
## Summary
- bump toolruntime to v0.4.0 and metatools-mcp to v0.5.0
- sync version matrix
- document WASM runtime integration in component docs

## Testing
- not run (docs/version matrix only)